### PR TITLE
Add Nova 5 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "laravel/nova": "^4.0"
+        "laravel/nova": "^4.0|^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
There are no breaking changes to allow Nova 5 support. Would appreciate a quick tag to publish the latest version. Fixes #6 

In the meantime, you can add Nova 5 support by modifying your `composer.json`:

Add the repo as a repository:

```
"repositories": [
  {
    "type": "composer",
    "url": "https://nova.laravel.com"
  },
  {
    "type": "vcs",
    "url": "https://github.com/grantholle/nova-logo-url"
  }
]
```

Set the version to be `@dev`:

```
"formfeed-uk/nova-logo-url": "@dev",
```